### PR TITLE
Add author name to slack message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -53,8 +53,9 @@ fn main() {
 
             // Send Slack alert
             let msg = format!(
-                "{} A new Tinker pull request.\n{}\n{}",
+                "{} A new Tinker pull request by {}.\n{}\n{}",
                 get_emoji(),
+                pr.author,
                 pr.title,
                 pr.url
             );

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,10 +26,16 @@ struct GHQueryResult {
 }
 
 #[derive(Deserialize, Debug)]
+struct GHUser {
+    login: String,
+}
+
+#[derive(Deserialize, Debug)]
 struct PullRequest {
     title: String,
     #[serde(rename = "html_url")]
     url: String,
+    user: GHUser,
 }
 
 fn main() {
@@ -55,7 +61,7 @@ fn main() {
             let msg = format!(
                 "{} A new Tinker pull request by {}.\n{}\n{}",
                 get_emoji(),
-                pr.author,
+                pr.user.login,
                 pr.title,
                 pr.url
             );


### PR DESCRIPTION
I've found myself looking through our channel to remind myself of recent PRs, and reading the titles is a bit more cumbersome than looking for who created it, which I usually remember. Disclosure, I haven't tested this as I haven't installed a Rust environment, but I assume that the author information should be there 👀 otherwise, take this as a suggestion rather than a contribution.