### PR TITLE
Update project board

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ reqwest = { version = "0.11", features = ["blocking", "json", "multipart"]}
 serde = { version = "1.0", features = ["derive"] }
 rusqlite = "0.25.3"
 toml = "0.5"
+serde_json = "1.0.59"


### PR DESCRIPTION
This PR proposes adding a Card to a specified column within a project when a new PR is found by the bot.

The bot:
1. Fetches a project by its project id, `github_project_id`.
2. Finds the column matching the `github_column_name` settings.
3. Adds a card to the column with the PR url and author.

Added the following settings:
- `github_project_id`: numeric id of the project. Can be found fetching an org's projects through the api. It's the global id of the project within github, not the sequential id found in the url.
- `github_column_name`: case insensitive name of the column where new cards will be added. Must exist before running.
- `github_username`: the github username for the bot.
- `github_token`: a personal access token with, at least, full repo scope.